### PR TITLE
Accepting command line arguments

### DIFF
--- a/EasySIMBL/AppDelegate.m
+++ b/EasySIMBL/AppDelegate.m
@@ -81,6 +81,24 @@
     } else {
         [self.useSIMBL setEnabled:NO];
     }
+    // enable/disable agent via command line
+    NSNumber *enableCommand = [[NSUserDefaults standardUserDefaults] objectForKey:@"enabled"];
+    if(enableCommand != nil && self.useSIMBL.enabled) { // checks existence of "enabled" parameter
+        BOOL wantsEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"enabled"]; // BOOL can be 0/1, YES/NO, Y/N,...
+        BOOL isEnabled = self.useSIMBL.state == NSOnState;
+        if(wantsEnabled != isEnabled) { // toggle
+            SIMBLLogInfo(@"'SIMBL Agent' toggling state via command line.");
+            self.useSIMBL.state = wantsEnabled ? NSOnState : NSOffState;
+            [self toggleUseSIMBL:nil];
+        } else {
+            SIMBLLogInfo(@"'SIMBL Agent' is already in the desired state.");
+        }
+        // also check for command "quit"
+        BOOL quitCommand = [[NSUserDefaults standardUserDefaults] boolForKey:@"quit"];
+        if(quitCommand) {
+            [[NSApplication sharedApplication] terminate:self];
+        }
+    }
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theApplication

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ Tested combinations of OS X and applications
 
 _PowerboxInjector is not compatible with EasySIMBL. Sorry, the reason exists on EasySIMBL side._
 
+Automated install/uninstall
+---------------------------
+
+You can enable/disable SIMBL by running the application with some command line parameters:
+
+To enable:
+```
+$ /Applications/EasySIMBL.app/Contents/MacOS/EasySIMBL -enabled YES
+```
+
+To disable:
+```
+$ /Applications/EasySIMBL.app/Contents/MacOS/EasySIMBL -enabled NO
+```
+
+You can also quit EasySIMBL immediately after doing the change: 
+```
+$ /Applications/EasySIMBL.app/Contents/MacOS/EasySIMBL -enabled YES -quit YES
+```
+
 License
 -------
 	Copyright 2003-2009, Mike Solomon <mas63@cornell.edu>


### PR DESCRIPTION
I realized there's no programatic way to activate SIMBL after copying the application bundle to Applications. While this is fine for an end user, some people might need to do this automatically, eg. when including the application in an installer or distributing to a network of computers.

Here's a proposed solution.
